### PR TITLE
Mad/payloads launched update

### DIFF
--- a/PayloadsLaunched/index.html
+++ b/PayloadsLaunched/index.html
@@ -19,6 +19,7 @@
   <script src="https://code.highcharts.com/highcharts-more.js"></script>
   <script src="https://code.highcharts.com/maps/modules/data.js"></script>
   <script src="https://code.highcharts.com/maps/modules/exporting.js"></script>
+  <script src="https://code.highcharts.com/modules/broken-axis.js"></script>
   <!-- Include iFrame Resizer -->
   <script src="https://csis-ilab.github.io/aerospace-viz/globals/iframeSizer.contentWindow.min.js"></script>
   <!-- Include Project Specific Highcharts Theme -->

--- a/PayloadsLaunched/js/area.js
+++ b/PayloadsLaunched/js/area.js
@@ -1,4 +1,42 @@
 $(function() {
+  /**
+ * Extend the Axis.getLinePath method in order to visualize breaks with two parallel
+ * slanted lines. For each break, the slanted lines are inserted into the line path.
+ */
+  Highcharts.wrap(Highcharts.Axis.prototype, 'getLinePath', function (proceed, lineWidth) {
+      var axis = this,
+          brokenAxis = axis.brokenAxis,
+          path = proceed.call(this, lineWidth),
+          start = path[0],
+          x = start[1],
+          y = start[2];
+
+      (brokenAxis.breakArray || []).forEach(function (brk) {
+          if (axis.horiz) {
+              x = axis.toPixels(brk.from);
+              path.splice(1, 0,
+                  ['L', x - 4, y], // stop
+                  ['M', x - 9, y + 5],
+                  ['L', x + 1, y - 5], // left slanted line
+                  ['M', x - 1, y + 5],
+                  ['L', x + 9, y - 5], // higher slanted line
+                  ['M', x + 4, y]
+              );
+          } else {
+              y = axis.toPixels(brk.from);
+              path.splice(1, 0,
+                  ['L', x, y - 4], // stop
+                  ['M', x + 5, y - 9],
+                  ['L', x - 5, y + 1], // lower slanted line
+                  ['M', x + 5, y - 1],
+                  ['L', x - 5, y + 9], // higher slanted line
+                  ['M', x, y + 4]
+              );
+          }
+      });
+      return path;
+  });
+
   $('#hcContainer').highcharts({
     // Load Data in from Google Sheets
     data: {
@@ -30,12 +68,28 @@ $(function() {
       verticalAlign: 'bottom',
       layout: 'horizontal'
     },
+    xAxis: {
+      lineColor: '#000',
+      lineWidth: 1
+    },
     // Y Axis
     yAxis: {
-      type: "logarithmic",
-      tickPositions: [0, 10, 50, 250, 500, 1000, 2000].map((v) =>
-        Math.log10(v)
-      ),
+      lineColor: '#000',
+      lineWidth: 1,
+      //type: "logarithmic",
+      //tickPositions: [0, 10, 50, 250, 500, 1000, 2000].map((v) =>
+        //Math.log10(v)
+      //),
+      labels: {
+        x: -15
+      },
+      tickInterval:  250,
+      breaks: [{
+        from: 250,
+        to: 900,
+        breakSize: 1
+      }],
+      max: 1750,
       title: {
         text: "Total Payloads Launched per Year"
       },

--- a/PayloadsLaunched/js/area.js
+++ b/PayloadsLaunched/js/area.js
@@ -32,6 +32,10 @@ $(function() {
     },
     // Y Axis
     yAxis: {
+      type: "logarithmic",
+      tickPositions: [0, 10, 50, 250, 500, 1000, 2000].map((v) =>
+        Math.log10(v)
+      ),
       title: {
         text: "Total Payloads Launched per Year"
       },

--- a/PayloadsLaunched/js/area.js
+++ b/PayloadsLaunched/js/area.js
@@ -49,6 +49,7 @@ $(function() {
       zoomType: 'x',
       type: 'area'
     },
+    colors: ["#f9bc65", "#196c95", "#d66e42"],
     // Chart Title and Subtitle
     title: {
       text: "Payloads Launched by Country"


### PR DESCRIPTION
## What
Request from ASP to update chart  for readability - the U.S. had a huge spike in payload launches over the past two years, which made it difficult to see the number of payloads launched by Russia and China. 

## Result 
Update chart to use log scale, add break in y-axis to make clear. Update colors to match another chart on the ASP site.

## Screenshots 
### Before
<img width="1025" alt="Screen Shot 2022-08-12 at 8 56 46 AM" src="https://user-images.githubusercontent.com/41589348/184358929-3b3ef984-2bb6-4d99-927d-c4b4cbd57dca.png">

### After
<img width="1116" alt="Unknown" src="https://user-images.githubusercontent.com/41589348/184358950-79acb7c7-8880-44bd-a50a-5b850c540624.png">

